### PR TITLE
Manage server reports

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+    <name>jenkinstracking</name>
+    <comment></comment>
+    <projects></projects>
+    <buildSpec>
+        <buildCommand>
+            <name>com.puppetlabs.geppetto.pp.dsl.ui.modulefileBuilder</name>
+            <arguments></arguments>
+        </buildCommand>
+        <buildCommand>
+            <name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+            <arguments></arguments>
+        </buildCommand>
+    </buildSpec>
+    <natures>
+        <nature>com.puppetlabs.geppetto.pp.dsl.ui.puppetNature</nature>
+        <nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+    </natures>
+</projectDescription>

--- a/README.md
+++ b/README.md
@@ -19,3 +19,89 @@ In the above example, the `track` resource captues the fingerprint of `/var/lib/
 See [deployment notification plugin](https://wiki.jenkins-ci.org/display/JENKINS/Deployment+Notification+Plugin) and [puppet plugin](https://wiki.jenkins-ci.org/display/JENKINS/Puppet+Plugin) for how these things work together.
 
 This module is [being considered](https://github.com/jenkinsci/puppet-jenkins/issues/110) for an inclusion into [the puppet-jenkins module](https://github.com/jenkinsci/puppet-jenkins).
+
+## Integrating the jenkinstracking Report Type
+
+This module also provides a custom report which your Puppet servers can use to publish tracking data to your Jenkins server.  Integration is very simple.  You need only classify your Puppet server with this module and set -- at minimum -- the Puppet report submission URL for your Jenkins server.
+
+### The r10k Puppetfile
+
+To enable Puppet-Jenkins integration, the minimum set of modules for your Puppetfile include (while you may only want `jenkins` and `jenkinsracking`, they depend on other Puppet modules):
+
+```
+mod "camptocamp/systemd"
+mod "puppet/archive"
+mod "puppet/zypprepo"
+mod "puppetlabs/apt"
+mod "puppetlabs/inifile"
+mod "puppetlabs/java"
+mod "puppetlabs/stdlib"
+mod "puppetlabs/transition"
+mod "rtyler/jenkins"
+mod "wwkimball/jenkinstracking",
+  :git => https://github.com/wwkimball/puppet/jenkinstracking.git
+```
+
+### YAML Configuration Example
+
+If you are using the popular Hiera-as-ENC pattern, the following examples illustrate the least amount of configuration you'd need to achieve integration between Puppet and Jenkins for deployment artifact tracking:
+
+#### Minimum YAML configuration for your Puppet server
+
+This example classifies your Puppet servers with the `jenkinstracking` Puppet module.  It also illustrates the least amount of configuration that is required for the Puppet servers to begin publishing tracked resources to your Jenkins server.  Of course, this class provides more configuration options but -- omitting `report_url` -- the defaults are typically enough to get going out-of-the-box.
+
+```
+---
+classes:
+  - jenkinstracking
+
+# You must specify your own Jenkins report submission URL, even if you manage
+# your puppet.conf file by other means.
+jenkinstracking::report_url: https://report_user:api_token@jenkins-server/puppet/report
+```
+
+#### Minimum YAML configuration for your Jenkins server
+
+This example classifies your Jenkins server with the `jenkins` Puppet module.  It also illustrates the bare minimum required configuration to enable Puppet-Jenkins integration.  The very long list of entries for `plugin_hash` is entirely required due to plug-in inter-dependencies.  To wit, even if you don't use VMWare's vSphere products, you must still install the `vsphere-cloud` plug-in because it is part of the dependency tree for the `puppet` plug-in.  Your actual list of plug-ins -- and their dependencies -- will likely be considerably longer than this; these are merely the bare minimum required to enable Puppet-Jenkins integration.
+
+```
+classes:
+  - jenkins
+
+jenkins::plugin_hash:
+  # Provides the jenkins/puppet/report access point for Puppet to publish reports
+  'puppet': {}
+
+  # Required by the puppet plug-in
+  'deployment-notification': {}
+
+  # Required by deployment-notification
+  'apache-httpcomponents-client-4-api': {}
+  'cloudbees-folder': {}
+  'config-file-provider': {}
+  'credentials': {}
+  'display-url-api': {}
+  'javadoc': {}
+  'job-dsl': {}
+  'jsch': {}
+  'junit': {}
+  'mailer': {}
+  'managed-scripts': {}
+  'maven-plugin': {}
+  'node-iterator-api': {}
+  'project-inheritance': {}
+  'promoted-builds': {}
+  'rebuild': {}
+  'scm-api': {}
+  'script-security': {}
+  'ssh-credentials': {}
+  'ssh-slaves': {}
+  'structs': {}
+  'token-macro': {}
+  'vsphere-cloud': {}
+  'workflow-api': {}
+  'workflow-basic-steps': {}
+  'workflow-job': {}
+  'workflow-step-api': {}
+  'workflow-support': {}
+```

--- a/data/FreeBSD.yaml
+++ b/data/FreeBSD.yaml
@@ -1,0 +1,8 @@
+---
+################################################################################
+# Default settings for FreeBSD distributions.  These settings join with and
+# override those specified within all.yaml.
+################################################################################
+jenkinstracking::puppet_conf_file: /usr/local/etc/puppetlabs/puppet/puppet.conf
+
+# vim: syntax=yaml:tabstop=2:softtabstop=2:shiftwidth=2:expandtab:ai

--- a/data/all.yaml
+++ b/data/all.yaml
@@ -1,0 +1,12 @@
+---
+################################################################################
+# Default settings for all deployment scenarios.
+################################################################################
+jenkinstracking::manage_report_processor: true
+jenkinstracking::manage_report_url: true
+jenkinstracking::puppet_conf_file: /etc/puppetlabs/puppet/puppet.conf
+jenkinstracking::report_processor_ensure: present
+jenkinstracking::report_url_ensure: present
+jenkinstracking::stand_alone: false
+
+# vim: syntax=yaml:tabstop=2:softtabstop=2:shiftwidth=2:expandtab:ai

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,15 @@
+---
+################################################################################
+# Hiera configuration file for this Puppet module.
+################################################################################
+version: 5
+
+defaults:
+  data_hash: yaml_data
+  datadir: data
+
+hierarchy:
+  - name: Module defaults
+    paths:
+      - "%{facts.os.family}"
+      - all.yaml

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,32 @@
+# Optionally manages the [main|master]reports and reporturl entries of
+# puppet.conf to add or remove the jenkinstracking report processor.  See the
+# init.pp file for usage examples.
+class jenkinstracking::config {
+  if $jenkinstracking::stand_alone {
+    $ini_section = 'main'
+  } else {
+    $ini_section = 'master'
+  }
+
+  if $jenkinstracking::manage_report_processor {
+	  ini_subsetting { "puppet.conf/${ini_section}/reports/jenkinstracking":
+	    ensure               => $jenkinstracking::report_processor_ensure,
+	    path                 => $jenkinstracking::puppet_conf_file,
+	    section              => $ini_section,
+	    setting              => 'reports',
+	    subsetting           => 'jenkinstracking',
+	    subsetting_separator => ',',
+	  }
+	}
+
+  if $jenkinstracking::manage_report_url {
+    ini_setting { "puppet.conf/${ini_section}/reporturl":
+      ensure  => $jenkinstracking::report_url_ensure,
+      path    => $jenkinstracking::puppet_conf_file,
+      section => $ini_section,
+      setting => 'reporturl',
+      value   => $jenkinstracking::report_url,
+    }
+  }
+}
+# vim: syntax=puppet:tabstop=2:softtabstop=2:shiftwidth=2:expandtab:ai

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,60 @@
+# Manage the installation of the jenkinstracking report processor on the Puppet
+# server.
+#
+# @param manage_report_processor Indicates whether to manage the reports key of
+#  the puppet.conf file on this node.  When `false`, the setting will neither be
+#  added nor removed.  So, if you are trying to *remove* this report processor,
+#  you must still set `manage_report_processor` to `true` for a setting of
+#  `report_processor_ensure` of `absent` to be meaningful.  The same holds true
+#  for the `report_url` setting.
+# @param manage_report_url ------------------------------------------------------
+# @param report_url -------------------------------------------------------------
+# @param report_url_ensure ------------------------------------------------------
+# @param puppet_conf_file Fully-qualified path to the puppet.conf file.
+# @param report_processor_ensure Indicate whether to keep the jenkinstracking
+#  report processor in or out of the puppet.conf file.
+# @param stand_alone Indicates whether the node is stand-alone (no Puppet
+#  server).
+#
+# @example Default: keep the jenkinstracking report processor active
+#  ---
+#  classes:
+#    - jenkinstracking
+#
+#  # You must specify your own Jenkins report submission URL, even if you manage
+#  # your puppet.conf file by other means.
+#  jenkinstracking::report_url: https://report_user:api_token@jenkins-server/puppet/report
+#
+# @example Remove the jenkinstracking report processor
+#  ---
+#  classes:
+#    - jenkinstracking
+#
+#  # You must still specify your own Jenkins report submission URL, even if you
+#  # manage your puppet.conf file by other means.
+#  jenkinstracking::report_url: https://report_user:api_token@jenkins-server/puppet/report
+#  jenkinstracking::report_processor_ensure: absent
+#
+# @example Disable management of the puppet.conf file
+#  ---
+#  classes:
+#    - jenkinstracking
+#
+#  # You must still specify your own Jenkins report submission URL, even if you
+#  # manage your puppet.conf file by other means.
+#  jenkinstracking::report_url: https://report_user:api_token@jenkins-server/puppet/report
+#  jenkinstracking::manage_report_processor: false
+#
+class jenkinstracking(
+  Boolean                   $manage_report_processor,
+  Boolean                   $manage_report_url,
+  Stdlib::Absolutepath      $puppet_conf_file,
+  Enum['present', 'absent'] $report_processor_ensure,
+  Enum['present', 'absent'] $report_url_ensure,
+  Stdlib::HTTPUrl           $report_url,
+  Boolean                   $stand_alone,
+) {
+  class { '::jenkinstracking::config': }
+  -> Class['jenkinstracking']
+}
+# vim: syntax=puppet:tabstop=2:softtabstop=2:shiftwidth=2:expandtab:ai

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,27 @@
+{
+  "name": "wkimball-jenkinstracking",
+  "version": "0.1.0",
+  "author": "",
+  "license": "Apache v2",
+  "summary": "Manages jenkinstracking",
+  "source": "https://github.com/wwkimball/puppet-jenkinstracking",
+  "project_page": "https://bitbucket.org/kimballstuff/jenkinstracking",
+  "dependencies": [],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": ["7"]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": ["7"]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">4"
+    }
+  ],
+  "tags": []
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,15 @@
 {
-  "name": "wkimball-jenkinstracking",
+  "name": "wwkimball-jenkinstracking",
   "version": "0.1.0",
-  "author": "",
+  "author": "wwkimball",
   "license": "Apache v2",
-  "summary": "Manages jenkinstracking",
+  "summary": "Manages the jenkinstracking report processor for Puppet servers",
   "source": "https://github.com/wwkimball/puppet-jenkinstracking",
-  "project_page": "https://bitbucket.org/kimballstuff/jenkinstracking",
-  "dependencies": [],
+  "project_page": "https://github.com/wwkimball/puppet-jenkinstracking",
+  "dependencies": [
+    { "name": "puppetlabs/stdlib", "version_requirement": "4.x" },
+    { "name": "puppetlabs/inifile", "version_requirement": "2.x" }
+  ],
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
@@ -18,10 +21,7 @@
     }
   ],
   "requirements": [
-    {
-      "name": "puppet",
-      "version_requirement": ">4"
-    }
+    { "name": "puppet", "version_requirement": "5.x" }
   ],
-  "tags": []
+  "tags": [ "jenkins" ]
 }


### PR DESCRIPTION
Optionally manages configuration of puppet.conf's reports and reporturl settings appropriate to stand-alone and server/agent settings.  This simplifies (automates) Puppet-Jenkins integration by enabling configuration of those settings that are necessary to publish tracked resource reports to Jenkins.